### PR TITLE
Molecule Environment fix

### DIFF
--- a/environments/molecule.yml
+++ b/environments/molecule.yml
@@ -42,7 +42,7 @@ instances:
     network: "{{ instance_network | default('default') }}"
     tags:
       - key: "AnsibleGroup"
-        value: "nodes"
+        value: "moleculenodes"
       - key: "ostype"
         value: "linux"
       - key: "instance_filter"


### PR DESCRIPTION
Molecule node group is changed to 'moleculenodes' as fix against host registration. 